### PR TITLE
Feature/webhook poller

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,29 @@ Available options:
 - `WithMessages(msgs MessageProvider)`: Use custom message provider
 - `WithUpdateLogger(l UpdateLogger)`: Use custom update logger
 
+### Webhook Configuration
+
+Bote supports webhooks for receiving updates from Telegram, which can be more efficient than long polling in some environments.
+
+To configure webhooks, you need to set the following fields in the `bote.Config` struct or use their corresponding environment variables:
+
+- **`WebhookURL`** (`string`): The publicly accessible HTTPS URL for your webhook. Telegram will send updates to this URL.
+  - Environment variable: `BOTE_WEBHOOK_URL`
+- **`ListenAddress`** (`string`): The IP address and port the bot will listen on for incoming webhook requests (e.g., `:8443` or `0.0.0.0:8080`).
+  - Environment variable: `BOTE_LISTEN_ADDRESS`
+  - Defaults to `:8443` if `WebhookURL` is set and `ListenAddress` is not.
+- **`TLSKeyFile`** (`string`, optional): Path to your TLS private key file. Required if you want the bot to handle HTTPS directly.
+  - Environment variable: `BOTE_TLS_KEY_FILE`
+- **`TLSCertFile`** (`string`, optional): Path to your TLS public certificate file. Required if you want the bot to handle HTTPS directly.
+  - Environment variable: `BOTE_TLS_CERT_FILE`
+
+**When to use TLS Key/Cert files:**
+
+- If your bot is directly exposed to the internet and you want it to handle HTTPS encryption itself, provide both `TLSKeyFile` and `TLSCertFile`.
+- If your bot is behind a reverse proxy (like Nginx or Caddy) that handles HTTPS termination, you typically don't need to set `TLSKeyFile` and `TLSCertFile` in the bot's configuration. The reverse proxy would forward plain HTTP traffic to the `ListenAddress` of the bot.
+
+Make sure your `WebhookURL` is correctly pointing to where your bot is listening, and that your firewall/network configuration allows Telegram servers to reach your `ListenAddress`.
+
 ### States
 
 States in Bote track the user's progress and context. Create custom states like this:

--- a/bot.go
+++ b/bot.go
@@ -546,14 +546,17 @@ func newBaseBot(token string, opts Options) (*baseBot, error) {
 		}
 	} else {
 		webhook := &tele.Webhook{
-			Listen: opts.Config.ListenAddress,
-			Endpoint: &tele.WebhookEndpoint{
-				PublicURL: opts.Config.WebhookURL,
-			},
+			Listen:   opts.Config.ListenAddress,
+			Endpoint: &tele.WebhookEndpoint{PublicURL: opts.Config.WebhookURL},
 		}
 		if opts.Config.TLSKeyFile != "" && opts.Config.TLSCertFile != "" {
-			webhook.Endpoint.PublicKey = opts.Config.TLSCertFile
-			webhook.KeyFile = opts.Config.TLSKeyFile
+			webhook.TLS = &tele.WebhookTLS{
+				Key:  opts.Config.TLSKeyFile,
+				Cert: opts.Config.TLSCertFile,
+			}
+			// Endpoint.Cert is used by Telegram to verify the certificate presented by the bot.
+			// It should be the public certificate file.
+			webhook.Endpoint.Cert = opts.Config.TLSCertFile
 		}
 		poller = webhook
 	}

--- a/bote_test.go
+++ b/bote_test.go
@@ -1141,3 +1141,145 @@ func TestFormatting(t *testing.T) {
 	assert.Equal(t, "<b>Test message</b>", bote.F(text, bote.Bold))
 	assert.Equal(t, "<i>Test message</i>", bote.F(text, bote.Italic))
 }
+
+func TestBotInitialization_PollerSelection(t *testing.T) {
+	// Test Case 1: Default (Long Poller)
+	t.Run("DefaultLongPoller", func(t *testing.T) {
+		boteBot, err := bote.New("test_token", bote.WithTestMode(NewTestPoller())) // Using TestMode to avoid actual API calls & provide a poller
+		assert.NoError(t, err)
+		if assert.NotNil(t, boteBot) {
+			teleBot := boteBot.Bot()
+			if assert.NotNil(t, teleBot) && assert.NotNil(t, teleBot.Poller) {
+				// The poller is wrapped by MiddlewarePoller, so we need to check the actual poller inside it.
+				// This requires inspecting the MiddlewarePoller's Poller field, which might not be directly accessible.
+				// For now, we assume that if WebhookURL is not set, it defaults to LongPoller.
+				// A more robust check would involve reflection or a getter for the wrapped poller if telebot provides it.
+				// As direct type assertion on teleBot.Poller will fail because it's a *tele.MiddlewarePoller.
+				// We check if it's *not* a WebhookPoller as an indirect way for now.
+				// Ideally, bote.Bot could expose its configured poller type or tele.MiddlewarePoller could expose its inner poller.
+				// For the purpose of this test, we'll create a bot *without* WithTestMode's poller to inspect the default.
+				opts := bote.Options{
+					Config: bote.Config{TestMode: true}, // Keep TestMode to prevent actual polling
+				}
+				defaultBot, err := bote.NewWithOptions("test_token", opts)
+				assert.NoError(t, err)
+				if assert.NotNil(t, defaultBot) {
+					actualTeleBot := defaultBot.Bot()
+					if assert.NotNil(t, actualTeleBot) && assert.NotNil(t, actualTeleBot.Poller) {
+						middlewarePoller, ok := actualTeleBot.Poller.(*tele.MiddlewarePoller)
+						if assert.True(t, ok, "Poller should be MiddlewarePoller") {
+							assert.IsType(t, &tele.LongPoller{}, middlewarePoller.Poller, "Underlying poller should be LongPoller")
+						}
+					}
+				}
+			}
+		}
+	})
+
+	// Test Case 2: Webhook Poller (No TLS)
+	t.Run("WebhookPoller_NoTLS", func(t *testing.T) {
+		opts := bote.Options{
+			Config: bote.Config{
+				WebhookURL:    "https://test.com/webhook",
+				ListenAddress: "127.0.0.1:8080",
+				TestMode:      true, // Important to prevent actual network operations
+			},
+		}
+		boteBot, err := bote.NewWithOptions("test_token", opts)
+		assert.NoError(t, err)
+		if assert.NotNil(t, boteBot) {
+			teleBot := boteBot.Bot()
+			if assert.NotNil(t, teleBot) && assert.NotNil(t, teleBot.Poller) {
+				middlewarePoller, ok := teleBot.Poller.(*tele.MiddlewarePoller)
+				if assert.True(t, ok, "Poller should be MiddlewarePoller") {
+					webhookPoller, ok := middlewarePoller.Poller.(*tele.Webhook)
+					if assert.True(t, ok, "Underlying poller should be Webhook") {
+						assert.Equal(t, "127.0.0.1:8080", webhookPoller.Listen)
+						if assert.NotNil(t, webhookPoller.Endpoint) {
+							assert.Equal(t, "https://test.com/webhook", webhookPoller.Endpoint.PublicURL)
+						}
+						assert.Empty(t, webhookPoller.KeyFile, "TLSKeyFile should be empty")
+						assert.Empty(t, webhookPoller.Endpoint.PublicKey, "TLSCertFile (PublicKey) should be empty")
+					}
+				}
+			}
+		}
+	})
+
+	// Test Case 3: Webhook Poller (With TLS)
+	t.Run("WebhookPoller_WithTLS", func(t *testing.T) {
+		opts := bote.Options{
+			Config: bote.Config{
+				WebhookURL:    "https://test.com/webhook_tls",
+				ListenAddress: "127.0.0.1:8443",
+				TLSCertFile:   "test_cert.pem",
+				TLSKeyFile:    "test_key.pem",
+				TestMode:      true, // Important
+			},
+		}
+		boteBot, err := bote.NewWithOptions("test_token", opts)
+		assert.NoError(t, err)
+		if assert.NotNil(t, boteBot) {
+			teleBot := boteBot.Bot()
+			if assert.NotNil(t, teleBot) && assert.NotNil(t, teleBot.Poller) {
+				middlewarePoller, ok := teleBot.Poller.(*tele.MiddlewarePoller)
+				if assert.True(t, ok, "Poller should be MiddlewarePoller") {
+					webhookPoller, ok := middlewarePoller.Poller.(*tele.Webhook)
+					if assert.True(t, ok, "Underlying poller should be Webhook") {
+						assert.Equal(t, "127.0.0.1:8443", webhookPoller.Listen)
+						if assert.NotNil(t, webhookPoller.Endpoint) {
+							assert.Equal(t, "https://test.com/webhook_tls", webhookPoller.Endpoint.PublicURL)
+							assert.Equal(t, "test_cert.pem", webhookPoller.Endpoint.PublicKey)
+						}
+						assert.Equal(t, "test_key.pem", webhookPoller.KeyFile)
+					}
+				}
+			}
+		}
+	})
+
+	// Test Case 4: Invalid Webhook Config (e.g., TLS files set, URL missing)
+	// This relies on validation in options.go's prepareAndValidate
+	t.Run("WebhookPoller_InvalidConfig_MissingURL", func(t *testing.T) {
+		opts := bote.Options{
+			Config: bote.Config{
+				// WebhookURL is missing
+				ListenAddress: "127.0.0.1:8443",
+				TLSCertFile:   "test_cert.pem",
+				TLSKeyFile:    "test_key.pem",
+				TestMode:      true,
+			},
+		}
+		_, err := bote.NewWithOptions("test_token", opts)
+		assert.Error(t, err, "Expected an error due to invalid webhook configuration (missing URL)")
+		// Check if the error message indicates the URL issue, if possible and stable.
+		// For now, just checking for any error is sufficient as specific error messages can be brittle.
+	})
+
+	t.Run("WebhookPoller_InvalidConfig_OnlyOneTLSFile_Key", func(t *testing.T) {
+		opts := bote.Options{
+			Config: bote.Config{
+				WebhookURL:    "https://test.com/webhook",
+				ListenAddress: "127.0.0.1:8443",
+				TLSKeyFile:    "test_key.pem",
+				// TLSCertFile is missing
+				TestMode: true,
+			},
+		}
+		_, err := bote.NewWithOptions("test_token", opts)
+		assert.Error(t, err, "Expected an error due to invalid webhook configuration (missing cert file)")
+	})
+
+	t.Run("WebhookPoller_InvalidConfig_OnlyOneTLSFile_Cert", func(t *testing.T) {
+		opts := bote.Options{
+			Config: bote.Config{
+				WebhookURL:  "https://test.com/webhook",
+				TLSCertFile: "test_cert.pem",
+				// TLSKeyFile is missing
+				TestMode: true,
+			},
+		}
+		_, err := bote.NewWithOptions("test_token", opts)
+		assert.Error(t, err, "Expected an error due to invalid webhook configuration (missing key file)")
+	})
+}

--- a/bote_test.go
+++ b/bote_test.go
@@ -1194,10 +1194,14 @@ func TestBotInitialization_PollerSelection(t *testing.T) {
 				if assert.True(t, ok, "Poller should be MiddlewarePoller") {
 					webhookPoller, ok := middlewarePoller.Poller.(*tele.Webhook)
 					if assert.True(t, ok, "Underlying poller should be Webhook") {
-                        assert.Equal(t, "127.0.0.1:8080", webhookPoller.Listen)
-                        assert.NotNil(t, webhookPoller.Endpoint)
-                        assert.Equal(t, "https://test.com/webhook", webhookPoller.Endpoint.PublicURL)
-                        assert.Nil(t, webhookPoller.TLS, "TLS struct must be nil when no TLS files are supplied")
+						assert.Equal(t, "127.0.0.1:8080", webhookPoller.Listen)
+						if assert.NotNil(t, webhookPoller.Endpoint) {
+							assert.Equal(t, "https://test.com/webhook", webhookPoller.Endpoint.PublicURL)
+							assert.Empty(t, webhookPoller.Endpoint.Cert, "Endpoint.Cert should be empty for NoTLS case")
+						}
+						assert.Nil(t, webhookPoller.TLS, "TLS config should be nil for NoTLS case")
+					}
+				}
 			}
 		}
 	})

--- a/bote_test.go
+++ b/bote_test.go
@@ -1229,9 +1229,14 @@ func TestBotInitialization_PollerSelection(t *testing.T) {
 						assert.Equal(t, "127.0.0.1:8443", webhookPoller.Listen)
 						if assert.NotNil(t, webhookPoller.Endpoint) {
 							assert.Equal(t, "https://test.com/webhook_tls", webhookPoller.Endpoint.PublicURL)
-							assert.Equal(t, "test_cert.pem", webhookPoller.Endpoint.PublicKey)
+							assert.Equal(t, "test_cert.pem", webhookPoller.Endpoint.Cert) // Corrected: Was PublicKey
 						}
-						assert.Equal(t, "test_key.pem", webhookPoller.KeyFile)
+						if assert.NotNil(t, webhookPoller.TLS) { // Corrected: Check TLS struct
+							assert.Equal(t, "test_key.pem", webhookPoller.TLS.Key)     // Corrected: Was KeyFile
+							assert.Equal(t, "test_cert.pem", webhookPoller.TLS.Cert)    // Corrected: New check for TLS.Cert
+						} else {
+							assert.Fail(t, "webhookPoller.TLS should not be nil when TLSKeyFile and TLSCertFile are provided")
+						}
 					}
 				}
 			}

--- a/bote_test.go
+++ b/bote_test.go
@@ -1194,14 +1194,10 @@ func TestBotInitialization_PollerSelection(t *testing.T) {
 				if assert.True(t, ok, "Poller should be MiddlewarePoller") {
 					webhookPoller, ok := middlewarePoller.Poller.(*tele.Webhook)
 					if assert.True(t, ok, "Underlying poller should be Webhook") {
-						assert.Equal(t, "127.0.0.1:8080", webhookPoller.Listen)
-						if assert.NotNil(t, webhookPoller.Endpoint) {
-							assert.Equal(t, "https://test.com/webhook", webhookPoller.Endpoint.PublicURL)
-						}
-						assert.Empty(t, webhookPoller.KeyFile, "TLSKeyFile should be empty")
-						assert.Empty(t, webhookPoller.Endpoint.PublicKey, "TLSCertFile (PublicKey) should be empty")
-					}
-				}
+                        assert.Equal(t, "127.0.0.1:8080", webhookPoller.Listen)
+                        assert.NotNil(t, webhookPoller.Endpoint)
+                        assert.Equal(t, "https://test.com/webhook", webhookPoller.Endpoint.PublicURL)
+                        assert.Nil(t, webhookPoller.TLS, "TLS struct must be nil when no TLS files are supplied")
 			}
 		}
 	})

--- a/example/main.go
+++ b/example/main.go
@@ -16,6 +16,25 @@ func main() {
 	cfg := bote.Config{
 		DefaultLanguageCode: "ru",
 		NoPreview:           true,
+
+		// --- Webhook Configuration Example ---
+		// To use webhooks, uncomment and configure the following.
+		// The WebhookURL must be accessible from the internet and Telegram servers.
+		// ListenAddress is where the bot will listen for incoming updates from Telegram.
+		//
+		// If you're using a reverse proxy (e.g., Nginx) to handle HTTPS termination,
+		// you might not need to set TLSKeyFile and TLSCertFile here.
+		// The proxy would handle HTTPS and forward plain HTTP to your bot's ListenAddress.
+
+		// Example 1: Webhook without direct TLS handling by the bot (e.g., behind a reverse proxy)
+		// WebhookURL:    "https://your.domain.com/webhook-path", // Replace with your actual public URL
+		// ListenAddress: "0.0.0.0:8080",                       // Bot listens on port 8080 locally
+
+		// Example 2: Webhook with direct TLS handling by the bot
+		// WebhookURL:    "https://your.domain.com:8443/webhook-path", // Port in URL must match ListenAddress
+		// ListenAddress: "0.0.0.0:8443",
+		// TLSKeyFile:    "/path/to/your/private.key", // Replace with actual path
+		// TLSCertFile:   "/path/to/your/public.crt",  // Replace with actual path
 	}
 
 	b, err := bote.New(token, bote.WithConfig(cfg))


### PR DESCRIPTION
<!-- ai-desc-start -->
## **🤖 Review Summary**

This update introduces comprehensive support for Telegram webhooks, enabling bots to receive updates via HTTP callbacks as an alternative to long polling. It includes new configuration options for webhook URL, listen address, and TLS settings, alongside robust validation and updated documentation.

### **⚡️ New features**

-   **Webhook Support**:
    -   Adds the ability to configure the bot to receive updates from Telegram via webhooks, offering an efficient alternative to long polling for certain deployment environments.
    -   Introduces new configuration options in `bote.Config`: `WebhookURL`, `ListenAddress`, `TLSKeyFile`, and `TLSCertFile`.
    -   The bot now dynamically selects between long polling and webhook based on the presence of `WebhookURL` in the configuration. When `WebhookURL` is provided, a `tele.Webhook` poller is initialized, with optional TLS configuration for direct HTTPS handling.

### **🧪 Testing**

-   **Poller Selection and Webhook Configuration Tests**:
    -   New unit tests verify the correct selection of the poller type (Long Poller vs. Webhook) based on the bot's configuration.
    -   Tests cover various webhook configurations, including scenarios with and without TLS, and validate the correct setup of `ListenAddress`, `WebhookURL`, and TLS certificates.
    -   Validation tests for incomplete or invalid webhook configurations (e.g., missing URL, only one TLS file provided) are included to ensure robust error handling during initialization.

### **📚 Documentation**

-   **Webhook Configuration Guide**:
    -   The `README.md` has been updated with a dedicated section detailing how to configure webhooks. It explains each new configuration option and provides guidance on when to use direct TLS handling versus deploying behind a reverse proxy.
    -   The `example/main.go` file includes commented-out code snippets demonstrating how to set up webhook configurations for both direct TLS and reverse proxy scenarios.

### **🔄 Other changes**

-   **Configuration Validation**:
    -   Added validation logic to ensure that if `WebhookURL` is provided, it is a valid URL.
    -   Enforced that `TLSKeyFile` and `TLSCertFile` must both be provided or both be empty when webhook is enabled, preventing misconfigurations.
    -   A default `ListenAddress` of `:8443` is now automatically applied if `WebhookURL` is set but `ListenAddress` is not explicitly defined.
<!-- ai-desc-end -->

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Telegram webhook configuration, including options for listen address and TLS certificate/key files.
  * Users can now choose between long polling and webhook-based updates for their bots.

* **Documentation**
  * Updated README with a new section detailing webhook configuration, setup steps, and environment variables.
  * Added commented example configurations to illustrate webhook setup scenarios.

* **Bug Fixes**
  * Improved validation for webhook and TLS configuration to prevent invalid setups.

* **Tests**
  * Introduced comprehensive tests to verify correct poller selection and webhook configuration, including error handling for invalid setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->